### PR TITLE
test wth rollback of base image

### DIFF
--- a/07_uns_graphql/Dockerfile
+++ b/07_uns_graphql/Dockerfile
@@ -9,7 +9,7 @@
 #       e.g.
 #       docker run --name uns_graphql -v <full path to conf>/:/app/conf  --network=host uns/graphql:v0.5.0 
 # Use the official Python image
-FROM python:3.12-alpine3.19
+FROM python:3.12-alpine3.18
 
 # Set the environment variable for the entrypoint command
 ENV UNS_MODULE="07_uns_graphql"\


### PR DESCRIPTION
The build for uns_graphql docker is hanging with python:3.12-alpine3.19 hence downgrading to python:3.12-alpine3.18

See [Fail Run](https://github.com/mkashwin/unifiednamespace/actions/runs/8315249219)